### PR TITLE
fix: add corsheaders

### DIFF
--- a/main/settings/production.py
+++ b/main/settings/production.py
@@ -8,11 +8,11 @@ DEBUG = os.environ.get("DJANGO_DEBUG", False)
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS").split(",")
 
 # Application definition
-INSTALLED_APPS = base.INSTALLED_APPS + [
-    "storages",
-]
+INSTALLED_APPS = base.INSTALLED_APPS + ["storages", "corsheaders"]
 AUTH_USER_MODEL = base.AUTH_USER_MODEL
-MIDDLEWARE = base.MIDDLEWARE
+MIDDLEWARE = base.MIDDLEWARE + [
+    "corsheaders.middleware.CorsMiddleware",
+]
 ROOT_URLCONF = base.ROOT_URLCONF
 TEMPLATES = base.TEMPLATES
 WSGI_APPLICATION = base.WSGI_APPLICATION
@@ -74,6 +74,10 @@ STATIC_URL = base.STATIC_URL
 MEDIA_URL = base.MEDIA_URL
 STATICFILES_DIRS = base.STATICFILES_DIRS
 
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_HEADERS = [
+    "*",
+]
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = base.DEFAULT_AUTO_FIELD

--- a/main/urls.py
+++ b/main/urls.py
@@ -13,12 +13,10 @@ from drf_yasg import openapi
 
 schema_view = get_schema_view(
     openapi.Info(
-        title="Swagger Study API",
+        title="Amang API",
         default_version="v1",
-        description="Swagger Study를 위한 API 문서",
-        terms_of_service="https://www.google.com/policies/terms/",
-        contact=openapi.Contact(name="test", email="test@test.com"),
-        license=openapi.License(name="Test License"),
+        description="Amang 홈페이지를 위한 API",
+        contact=openapi.Contact(name="JangsuSon", email="manamana32321@gmail.com"),
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ click==8.1.7
 colorama==0.4.3
 distlib==0.3.8
 Django==5.1
+django-cors-headers==4.4.0
 django-debug-toolbar==4.4.6
 django-storages==1.14.4
 djangorestframework==3.15.2


### PR DESCRIPTION
S3는 `content-type=XML`으로 통신하기에 에러가 발생하는 것으로 보입니다.
따라서 임시로 모든 헤더를 허용합니다.